### PR TITLE
Décompose le html en section

### DIFF
--- a/src/cms/crispMarkdown.ts
+++ b/src/cms/crispMarkdown.ts
@@ -1,4 +1,4 @@
-import { Lexer, marked, Parser, RendererObject, Tokens } from 'marked';
+import { Lexer, Marked, Parser, RendererObject, Tokens } from 'marked';
 
 const extensionBoite = (regex: RegExp, nom: string, classe: string) => ({
   name: nom,
@@ -31,6 +31,7 @@ class CrispMarkdown {
   private contenuHTML: string | null = null;
   private aDejaParse: boolean = false;
   private tdm: any[] = [];
+  private marked: Marked;
 
   constructor(private contenuMarkdown: string) {
     const boiteAide = extensionBoite(/^\|([^|\n]+)/, 'boiteAide', 'aide');
@@ -70,6 +71,40 @@ class CrispMarkdown {
       },
     };
 
+    // Source d'inspiration pour la gestion des sections :
+    // https://github.com/markedjs/marked/discussions/2889
+    let niveauDeSection = 0;
+    const sectionRegexp = new RegExp(`^(# )[^]*?(?:\\n(?=\\1)|$)`);
+
+    const section = {
+      name: 'sectionBlock',
+      level: 'block',
+      start(source: string) {
+        return source.match(/^#/m)?.index;
+      },
+      tokenizer(this: { lexer: Lexer }, source: string) {
+        if (niveauDeSection > 0) return;
+        const match = source.match(sectionRegexp);
+        if (!match) {
+          return;
+        }
+
+        niveauDeSection++;
+        const tokens = this.lexer.blockTokens(match[0]);
+        niveauDeSection--;
+
+        return {
+          type: 'sectionBlock',
+          raw: match[0],
+          level: 1,
+          tokens,
+        };
+      },
+      renderer(this: { parser: Parser }, token: Tokens.Generic) {
+        return `<section>${this.parser.parse(token.tokens!)}</section>`;
+      },
+    };
+
     const moteurDeRendu = (that: CrispMarkdown): RendererObject => ({
       heading(this: RendererObject, ...[texte, profondeur]: any[]) {
         const slugDuTitre = texte.toLowerCase().replace(/\W+/g, '-');
@@ -89,14 +124,14 @@ class CrispMarkdown {
       },
     });
 
-    marked.use({
+    this.marked = new Marked({
       renderer: moteurDeRendu(this),
-      extensions: [boiteAide, boiteInfo, boiteAlerte, video],
-    });
+      extensions: [boiteAide, boiteInfo, boiteAlerte, video, section],
+    })
   }
 
   parseLeMarkdown() {
-    this.contenuHTML = marked.parse(this.contenuMarkdown) as string;
+    this.contenuHTML = this.marked.parse(this.contenuMarkdown) as string;
     this.aDejaParse = true;
   }
 

--- a/tests/cms/crispMarkdown.spec.ts
+++ b/tests/cms/crispMarkdown.spec.ts
@@ -1,6 +1,5 @@
-// const CrispMarkdown = require('../../src/cms/crispMarkdown');
-import { describe, it } from 'node:test';
 import assert from 'assert';
+import { describe, it } from 'node:test';
 import CrispMarkdown from '../../src/cms/crispMarkdown';
 
 describe('Le convertisseur de Markdown Crisp', () => {
@@ -54,7 +53,10 @@ describe('Le convertisseur de Markdown Crisp', () => {
 
       const resultat = crispMarkdown.versHTML();
 
-      assert.equal(resultat, "<h2 id='un-titre'>Un titre</h2>");
+      assert.equal(
+        resultat,
+        "<section><h2 id='un-titre'>Un titre</h2></section>"
+      );
     });
 
     it('contrains les niveaux de hierarchie entre 2 et 4', () => {
@@ -65,7 +67,7 @@ describe('Le convertisseur de Markdown Crisp', () => {
 
       assert.equal(
         resultat,
-        "<h2 id='un-titre'>Un titre</h2><h4 id='un-autre-titre'>Un autre titre</h4>"
+        "<section><h2 id='un-titre'>Un titre</h2><h4 id='un-autre-titre'>Un autre titre</h4></section>"
       );
     });
 
@@ -75,7 +77,10 @@ describe('Le convertisseur de Markdown Crisp', () => {
 
       const resultat = crispMarkdown.versHTML();
 
-      assert.equal(resultat, "<h2 id='un-titre'>Un titre</h2>");
+      assert.equal(
+        resultat,
+        "<section><h2 id='un-titre'>Un titre</h2></section>"
+      );
     });
   });
 
@@ -124,6 +129,20 @@ describe('Le convertisseur de Markdown Crisp', () => {
           id: 'un-sous-titre',
         },
       ]);
+    });
+  });
+
+  describe('concernant les sections', () => {
+    it('ajoute une section pour chaque titre', () => {
+      const entree = '# Un titre\ncontenu de la section';
+      const crispMarkdown = new CrispMarkdown(entree);
+
+      const resultat = crispMarkdown.versHTML();
+
+      assert.equal(
+        resultat,
+        "<section><h2 id='un-titre'>Un titre</h2><p>contenu de la section</p>\n</section>"
+      );
     });
   });
 });


### PR DESCRIPTION
... Lors du rendu du markdown venant de Crisp, on ajoute dynamiquement des sections autour des blocs logiques (titre + contenu)