### PR TITLE
Parse correctement les lignes horizontales

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lab-anssi/lib",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lab-anssi/lib",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/lib",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-lib.git"

--- a/src/cms/crispMarkdown.ts
+++ b/src/cms/crispMarkdown.ts
@@ -131,7 +131,8 @@ class CrispMarkdown {
   }
 
   parseLeMarkdown() {
-    this.contenuHTML = this.marked.parse(this.contenuMarkdown) as string;
+    const avecCorrectionLigneHorizontale = this.contenuMarkdown.replaceAll("\n---", "\n\n---");
+    this.contenuHTML = this.marked.parse(avecCorrectionLigneHorizontale) as string;
     this.aDejaParse = true;
   }
 

--- a/tests/cms/crispMarkdown.spec.ts
+++ b/tests/cms/crispMarkdown.spec.ts
@@ -46,6 +46,20 @@ describe('Le convertisseur de Markdown Crisp', () => {
     );
   });
 
+  it("reste robuste lorsqu'une image est suivie d'une ligne horizontale", () => {
+    const entree = '![](https://uneUrl.com)\n---\n';
+    const crispMarkdown = new CrispMarkdown(entree);
+
+    const resultat = crispMarkdown.versHTML();
+
+    assert.equal(
+        resultat,
+        '<p><img src="https://uneUrl.com" alt=""></p>\n' +
+        '<hr>\n'
+    );
+
+  });
+
   describe('concernant les titres', () => {
     it("diminue d'un niveau la hierarchie des titres afin de réserver le h1 pour le titre de la page", () => {
       const entree = '# Un titre';


### PR DESCRIPTION
... qui ne sont parfois pas précédées par un saut de ligne dans l'IHM Crisp. Cela a pour conséquence de casser tout le rendu HTML.