### PR TITLE
[NPM] Autorise le "trusted publishing"

### DIFF
--- a/.github/workflows/publication-npm.yml
+++ b/.github/workflows/publication-npm.yml
@@ -1,6 +1,7 @@
 name: Publication du package sur NPM
 permissions:
   id-token: write # Pour permettre le --provenance de la publication npm https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
+  contents: read
 
 on:
   release:
@@ -12,19 +13,19 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Récupérer la version
         run: echo "release_version=$(npm pkg get version --json | tr -d '\"')" >> $GITHUB_ENV
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Installer Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org/"
-          cache: 'pnpm'
+          package-manager-cache: false
 
       - name: Installer les dépendances
         run: pnpm install
@@ -37,5 +38,3 @@ jobs:
 
       - name: Publier sur NPM
         run: pnpm publish --provenance --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/lib",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-lib.git"


### PR DESCRIPTION
On suit [cette doc](https://docs.npmjs.com/trusted-publishers#github-actions-configuration) pour activer le trusted publishing et ne plus avoir à gérer de tokens npm : meilleure sécurité.

On suit le chemin tracé par https://github.com/betagouv/lab-anssi-ui-kit/pull/400